### PR TITLE
chore(deps): update go version to 1.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
       with:
-        version: v1.61
+        version: v1.64
 
   unit-test:
     name: Unit Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datolabs-io/go-backstage/v3
 
-go 1.23
+go 1.24.0
 
 require (
 	github.com/h2non/gock v1.2.0


### PR DESCRIPTION
Update Go version requirement from 1.23 to 1.24.0 to leverage latest language features and improvements.