### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.6
+        version: v2.4.0
 
   unit-test:
     name: Unit Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: CI-${{ github.ref }}
   cancel-in-progress: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datolabs-io/go-backstage/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/h2non/gock v1.2.0


### PR DESCRIPTION
Bump to the latest go, update linter and fix permissions.